### PR TITLE
restack/edit: Interpret GIT_EDITOR using sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v0.1.2 (unreleased)
+-------------------
+
+-   Interpret `GIT_EDITOR` using a shell.
+
+
 v0.1.2 (2017-10-29)
 -------------------
 

--- a/cmd/restack/edit.go
+++ b/cmd/restack/edit.go
@@ -75,7 +75,11 @@ func (e *editCmd) Execute([]string) error {
 		return fmt.Errorf("failed to close files: %v", err)
 	}
 
-	cmd := exec.Command(e.Editor, outFilePath)
+	// Because GIT_EDITOR is meant to be interpreted by the shell, we need to
+	// rely on sh to handle that. We run,
+	//   sh -c "$GIT_EDITOR $1" "restack" $FILE
+	// This has the effect of invoking GIT_EDITOR with the argument $FILE.
+	cmd := exec.Command("sh", "-c", e.Editor+` "$1"`, "restack", outFilePath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
As per [`git-var`][1], the `GIT_EDITOR` variable is meant to be
interpreted by a shell, not as a path to an executable.

So the following is possible and valid.

    export GIT_EDITOR="FOO=BAR myeditor --somearg"

This changes `restack edit` to invoke the editor using `sh -c` instead
of calling directly. This is equivalent to calling,

    sh -c "$GIT_EDITOR $1" "restack" "$filepath"

(The "restack" in there is the `$0` for the `sh -c` command.)

[1]: https://git-scm.com/docs/git-var#git-var-GITEDITOR