### PR TITLE
Handle fixup and squash instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ v0.3.0 (unreleased)
 -------------------
 
 -   Write the full edit script path to git configuration.
+-   Handle short-forms instructions.
+-   Handle `fixup` and `squash` instructions.
 
 
 v0.2.0 (2020-03-13)

--- a/mock_git_test.go
+++ b/mock_git_test.go
@@ -33,19 +33,19 @@ func (m *MockGit) EXPECT() *MockGitMockRecorder {
 	return m.recorder
 }
 
-// ListHeads mocks base method
-func (m *MockGit) ListHeads(arg0 context.Context) (map[string][]string, error) {
+// ListBranches mocks base method
+func (m *MockGit) ListBranches(arg0 context.Context) ([]Branch, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListHeads", arg0)
-	ret0, _ := ret[0].(map[string][]string)
+	ret := m.ctrl.Call(m, "ListBranches", arg0)
+	ret0, _ := ret[0].([]Branch)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListHeads indicates an expected call of ListHeads
-func (mr *MockGitMockRecorder) ListHeads(arg0 interface{}) *gomock.Call {
+// ListBranches indicates an expected call of ListBranches
+func (mr *MockGitMockRecorder) ListBranches(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListHeads", reflect.TypeOf((*MockGit)(nil).ListHeads), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBranches", reflect.TypeOf((*MockGit)(nil).ListBranches), arg0)
 }
 
 // RebaseHeadName mocks base method

--- a/restack_test.go
+++ b/restack_test.go
@@ -26,7 +26,7 @@ func TestGitRestacker(t *testing.T) {
 			RemoteName:     "origin",
 			RebaseHeadName: "feature",
 			KnownHeads: map[string][]string{
-				"hash1": []string{"feature"},
+				"hash1": {"feature"},
 			},
 			Give: []string{
 				"pick hash0 Do something",
@@ -49,7 +49,7 @@ func TestGitRestacker(t *testing.T) {
 			RemoteName:     "origin",
 			RebaseHeadName: "feature/wip",
 			KnownHeads: map[string][]string{
-				"hash1": []string{"feature/1", "feature/wip"},
+				"hash1": {"feature/1", "feature/wip"},
 			},
 			Give: []string{
 				"pick hash0 Do something",
@@ -78,10 +78,10 @@ func TestGitRestacker(t *testing.T) {
 			RemoteName:     "origin",
 			RebaseHeadName: "feature/wip",
 			KnownHeads: map[string][]string{
-				"hash1": []string{"feature/1"},
-				"hash3": []string{"feature/2"},
-				"hash7": []string{"feature/3"},
-				"hash9": []string{"feature/wip"},
+				"hash1": {"feature/1"},
+				"hash3": {"feature/2"},
+				"hash7": {"feature/3"},
+				"hash9": {"feature/wip"},
 			},
 			Give: []string{
 				"pick hash0 Do something 0",

--- a/restack_test.go
+++ b/restack_test.go
@@ -120,6 +120,50 @@ func TestGitRestacker(t *testing.T) {
 				"# exec git push -f origin feature/3",
 			},
 		},
+		{
+			Desc:           "fixup commit",
+			RebaseHeadName: "b",
+			Branches: []Branch{
+				{Name: "a", Hash: "hash1"},
+				{Name: "b", Hash: "hash3"},
+			},
+			Give: []string{
+				"pick hash0 do thing",
+				"pick hash1 another thing",
+				"fixup hash2 stuff",
+				"pick hash3 whatever",
+			},
+			Want: []string{
+				"pick hash0 do thing",
+				"pick hash1 another thing",
+				"fixup hash2 stuff",
+				"exec git branch -f a",
+				"",
+				"pick hash3 whatever",
+			},
+		},
+		{
+			Desc:           "squash commit",
+			RebaseHeadName: "b",
+			Branches: []Branch{
+				{Name: "a", Hash: "hash1"},
+				{Name: "b", Hash: "hash3"},
+			},
+			Give: []string{
+				"pick hash0 do thing",
+				"pick hash1 another thing",
+				"squash hash2 stuff",
+				"pick hash3 whatever",
+			},
+			Want: []string{
+				"pick hash0 do thing",
+				"pick hash1 another thing",
+				"squash hash2 stuff",
+				"exec git branch -f a",
+				"",
+				"pick hash3 whatever",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/restack_test.go
+++ b/restack_test.go
@@ -16,7 +16,7 @@ func TestGitRestacker(t *testing.T) {
 		Desc           string
 		RemoteName     string
 		RebaseHeadName string
-		KnownHeads     map[string][]string
+		Branches       []Branch
 
 		Give []string
 		Want []string
@@ -25,8 +25,8 @@ func TestGitRestacker(t *testing.T) {
 			Desc:           "No matches",
 			RemoteName:     "origin",
 			RebaseHeadName: "feature",
-			KnownHeads: map[string][]string{
-				"hash1": {"feature"},
+			Branches: []Branch{
+				{Name: "feature", Hash: "hash1"},
 			},
 			Give: []string{
 				"pick hash0 Do something",
@@ -48,8 +48,9 @@ func TestGitRestacker(t *testing.T) {
 			Desc:           "Branch at rebase head",
 			RemoteName:     "origin",
 			RebaseHeadName: "feature/wip",
-			KnownHeads: map[string][]string{
-				"hash1": {"feature/1", "feature/wip"},
+			Branches: []Branch{
+				{Name: "feature/1", Hash: "hash1"},
+				{Name: "feature/wip", Hash: "hash1"},
 			},
 			Give: []string{
 				"pick hash0 Do something",
@@ -77,11 +78,11 @@ func TestGitRestacker(t *testing.T) {
 			Desc:           "Rebase instructions missing",
 			RemoteName:     "origin",
 			RebaseHeadName: "feature/wip",
-			KnownHeads: map[string][]string{
-				"hash1": {"feature/1"},
-				"hash3": {"feature/2"},
-				"hash7": {"feature/3"},
-				"hash9": {"feature/wip"},
+			Branches: []Branch{
+				{Name: "feature/1", Hash: "hash1"},
+				{Name: "feature/2", Hash: "hash3"},
+				{Name: "feature/3", Hash: "hash7"},
+				{Name: "feature/wip", Hash: "hash9"},
 			},
 			Give: []string{
 				"pick hash0 Do something 0",
@@ -131,8 +132,8 @@ func TestGitRestacker(t *testing.T) {
 				RebaseHeadName(gomock.Any()).
 				Return(tt.RebaseHeadName, nil)
 			mockGit.EXPECT().
-				ListHeads(gomock.Any()).
-				Return(tt.KnownHeads, nil)
+				ListBranches(gomock.Any()).
+				Return(tt.Branches, nil)
 
 			src := bytes.NewBufferString(strings.Join(tt.Give, "\n") + "\n")
 			var dst bytes.Buffer


### PR DESCRIPTION
This adds support for fixup and squash instructions. If either
instruction is seen following a possible branch update, the `exec git
branch` command is deferred until the next non-fixup/squash instruction.

Resolves #2