### PR TITLE
make: Use relative path, add more lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,60 @@
-export GOBIN ?= $(CURDIR)/bin
+BIN = bin
+GO_FILES = $(shell \
+	find . -path '*/.*' -prune -o '(' -type f -a -name '*.go' ')' -print)
 
-MOCKGEN = $(GOBIN)/mockgen
-GOLINT = $(GOBIN)/golint
-STATICCHECK = $(GOBIN)/staticcheck
+RESTACK = $(BIN)/restack
+
+GOLINT = $(BIN)/golint
+MOCKGEN = $(BIN)/mockgen
+STATICCHECK = $(BIN)/staticcheck
+
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export GOBIN = $(PROJECT_ROOT)/$(BIN)
+
+.PHONY: all
+all: build lint test
+
+.PHONY: build
+build: $(RESTACK)
 
 .PHONY: test
-test:
-	go test -race -v ./...
-
-.PHONY: lint
-lint: $(GOLINT) $(STATICCHECK)
-	$(GOLINT) ./...
-	$(STATICCHECK) ./...
+test: $(GO_FILES)
+	go test -race ./...
 
 .PHONY: generate
 generate: $(MOCKGEN)
 	PATH=$(GOBIN):$$PATH go generate ./...
+
+.PHONY: lint
+lint: gofmt golint staticcheck gomodtidy
+
+.PHONY: gofmt
+gofmt:
+	$(eval FMT_LOG := $(shell mktemp -t gofmt.XXXXX))
+	@gofmt -e -s -l $(GO_FILES) > $(FMT_LOG) || true
+	@[ ! -s "$(FMT_LOG)" ] || \
+		(echo "gofmt failed. Please reformat the following files:" | \
+		cat - $(FMT_LOG) && false)
+
+.PHONY: golint
+golint: $(GOLINT)
+	$(GOLINT) ./...
+
+.PHONY: staticcheck
+staticcheck: $(STATICCHECK)
+	$(STATICCHECK) ./...
+
+.PHONY: gomodtidy
+gomodtidy: go.mod go.sum
+	go mod tidy
+		@if ! git diff --quiet $^; then \
+		echo "go mod tidy changed files:" && \
+		git status --porcelain $^ && \
+		false; \
+	fi
+
+$(RESTACK): $(GO_FILES)
+	go install github.com/abhinav/restack/cmd/restack
 
 $(MOCKGEN):
 	go install github.com/golang/mock/mockgen


### PR DESCRIPTION
Targets in `make` were using absolute paths
which made it a pain to do things like,

    make bin/restack

Use relative paths for the targets;
absolute is needed only for setting GOBIN.

Also add `gofmt` and `go mod tidy` checks.
