### PR TITLE
edit: Degrade for /tmp on different partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v0.5.1 (unreleased)
+-------------------
+
+-   On Linux, don't fail to edit if `/tmp` is mounted on a different partition.
+
+
 v0.5.0 (2021-09-13)
 -------------------
 

--- a/edit.go
+++ b/edit.go
@@ -55,7 +55,7 @@ func (e *Edit) Run(ctx context.Context) (err error) {
 		return fmt.Errorf("edit %q: %v", outFilePath, err)
 	}
 
-	if err := os.Rename(outFilePath, e.Path); err != nil {
+	if err := renameFile(outFilePath, e.Path); err != nil {
 		return fmt.Errorf("overwrite %q: %v", e.Path, err)
 	}
 

--- a/io.go
+++ b/io.go
@@ -1,0 +1,73 @@
+package restack
+
+import (
+	"errors"
+	"io"
+	"os"
+	"syscall"
+
+	"go.uber.org/multierr"
+)
+
+var _osRename = os.Rename
+
+func renameFile(src, dst string) error {
+	err := _osRename(src, dst)
+	if err == nil {
+		return nil
+	}
+
+	// If /tmp is mounted to a different partition (it often is),
+	// attempting to move the file will cause the error:
+	//   invalid cross-device link
+	//
+	// In that case, fall back to copying over the file
+	// and deleting the temporary file manually.
+	//
+	// This behavior is not the default
+	// because an atomic move is preferable.
+	if errors.Is(err, syscall.EXDEV) {
+		err = unsafeRenameFile(src, dst)
+	}
+
+	return err
+}
+
+// unsafeRenameFile is a variant of os.Rename
+// that operates by manually copying over the contents
+// and permissions of src to dst.
+func unsafeRenameFile(src, dst string) (err error) {
+	defer func() {
+		if err == nil {
+			// Delete src only if
+			// everything else succeeded.
+			err = os.Remove(src)
+		}
+	}()
+
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	r, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer multierr.AppendInvoke(&err, multierr.Close(r))
+
+	w, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer multierr.AppendInvoke(&err, multierr.Close(w))
+
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+
+	return multierr.Combine(
+		w.Sync(),
+		w.Chmod(info.Mode()),
+	)
+}

--- a/io_test.go
+++ b/io_test.go
@@ -1,0 +1,179 @@
+package restack
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Shortcut to ioutil.WriteFile.
+func writeFile(t testing.TB, path, body string, perm os.FileMode) {
+	t.Helper()
+
+	require.NoError(t,
+		ioutil.WriteFile(path, []byte(body), perm),
+		"write %q", path)
+}
+
+// Shortcut to ioutil.ReadFile + os.Stat.
+func readFileAndMode(t testing.TB, path string) (string, os.FileMode) {
+	t.Helper()
+
+	body, err := ioutil.ReadFile(path)
+	require.NoError(t, err, "read %q", path)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	return string(body), info.Mode()
+}
+
+func hijackRename(t testing.TB, newFn func(string, string) error) {
+	t.Helper()
+
+	oldFn := _osRename
+	t.Cleanup(func() { _osRename = oldFn })
+
+	_osRename = newFn
+}
+
+func TestRenameFile(t *testing.T) {
+
+	t.Run("success", func(t *testing.T) {
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar")
+
+		writeFile(t, src, "body", 0644)
+		require.NoError(t, renameFile(src, dst),
+			"rename failed")
+
+		got, perm := readFileAndMode(t, dst)
+		assert.Equal(t, "body", got, "body mismatch")
+		assert.Equal(t, os.FileMode(0644), perm,
+			"permissions mismatch")
+
+		_, err := os.Stat(src)
+		require.Error(t, err, "%q must not exist", src)
+	})
+
+	t.Run("cross-device link error", func(t *testing.T) {
+		hijackRename(t, func(string, string) error {
+			return fmt.Errorf("great sadness: %w", syscall.EXDEV)
+		})
+
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar")
+
+		writeFile(t, src, "body", 0644)
+		require.NoError(t, renameFile(src, dst),
+			"rename failed")
+
+		got, perm := readFileAndMode(t, dst)
+		assert.Equal(t, "body", got, "body mismatch")
+		assert.Equal(t, os.FileMode(0644), perm,
+			"permissions mismatch")
+
+		_, err := os.Stat(src)
+		require.Error(t, err, "%q must not exist", src)
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		hijackRename(t, func(string, string) error {
+			return errors.New("great sadness")
+		})
+
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar")
+
+		writeFile(t, src, "body", 0644)
+		require.Error(t, renameFile(src, dst),
+			"rename should fail")
+	})
+}
+
+func TestUnsafeRenameFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dst does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar")
+
+		writeFile(t, src, "body", 0644)
+
+		require.NoError(t, unsafeRenameFile(src, dst),
+			"unsafe rename failed")
+
+		got, perm := readFileAndMode(t, dst)
+		assert.Equal(t, "body", got, "body mismatch")
+		assert.Equal(t, os.FileMode(0644), perm,
+			"permissions mismatch")
+
+		_, err := os.Stat(src)
+		require.Error(t, err, "%q must not exist", src)
+	})
+
+	t.Run("dst exists", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar")
+
+		writeFile(t, src, "body1", 0755)
+		writeFile(t, dst, "body2", 0600)
+
+		require.NoError(t, unsafeRenameFile(src, dst),
+			"unsafe rename failed")
+
+		got, perm := readFileAndMode(t, dst)
+		assert.Equal(t, "body1", got, "body mismatch")
+		assert.Equal(t, os.FileMode(0755), perm,
+			"permissions mismatch")
+
+		_, err := os.Stat(src)
+		require.Error(t, err, "%q must not exist", src)
+	})
+
+	t.Run("dst failed", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar", "baz", "qux")
+		// Parent directories don't exist.
+
+		writeFile(t, src, "body", 0644)
+
+		err := unsafeRenameFile(src, dst)
+		require.Error(t, err, "unsafe rename should fail")
+
+		// src should rename unchanged.
+		got, perm := readFileAndMode(t, src)
+		assert.Equal(t, "body", got)
+		assert.Equal(t, os.FileMode(0644), perm,
+			"permissions mismatch")
+	})
+
+	t.Run("src does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		src := filepath.Join(tempDir, "foo")
+		dst := filepath.Join(tempDir, "bar")
+
+		require.Error(t, unsafeRenameFile(src, dst))
+	})
+}


### PR DESCRIPTION
On Linux, if `/tmp` is on a different partition than
the directory that holds .git,
attempts to rename with `os.Rename` will fail with:

    invalid cross-device link

To work around this, detect the failure
and copy the file and permissions over manually.
This is not as atomic as an `os.Rename`
but it's better than complete failure.
