### PR TITLE
Modernize code

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,10 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: make test
+      run: make cover
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 /bin
 /dist
 /changes.*.txt
+/cover.*

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ build: $(RESTACK)
 test: $(GO_FILES)
 	go test -race ./...
 
+.PHONY: cover
+cover:
+	go test -race -coverprofile=cover.out -coverpkg=./... ./...
+	go tool cover -html=cover.out -o cover.html
+
 .PHONY: generate
 generate: $(MOCKGEN)
 	PATH=$(GOBIN):$$PATH go generate ./...

--- a/cmd/restack/main_test.go
+++ b/cmd/restack/main_test.go
@@ -23,16 +23,16 @@ func TestRun_CommandErrors(t *testing.T) {
 	tests := []struct {
 		name string
 		give []string
-		want error
+		want string
 	}{
 		{
 			name: "no arguments",
-			want: errCommandUnspecified,
+			want: "no command specified",
 		},
 		{
 			name: "unknown command",
 			give: []string{"foo"},
-			want: errUnknownCommand("foo"),
+			want: `unrecognized command "foo"`,
 		},
 	}
 
@@ -44,7 +44,7 @@ func TestRun_CommandErrors(t *testing.T) {
 				Stderr: &stderr,
 			}
 
-			assert.ErrorIs(t, run(opts, tt.give), tt.want)
+			assert.ErrorContains(t, run(opts, tt.give), tt.want)
 			assert.NotEmpty(t, stderr.String(),
 				"stderr should contain usage")
 		})
@@ -171,7 +171,7 @@ func TestNewEdit_FileParsing(t *testing.T) {
 		args []string
 
 		want    string
-		wantErr error
+		wantErr string
 	}{
 		{
 			name: "path specified",
@@ -181,12 +181,12 @@ func TestNewEdit_FileParsing(t *testing.T) {
 		{
 			name:    "no path specified",
 			args:    []string{"-e", "foo"},
-			wantErr: errNoFileSpecified,
+			wantErr: "no file specified",
 		},
 		{
 			name:    "too many paths",
 			args:    []string{"foo", "bar"},
-			wantErr: errTooManyArguments{Got: 2, Want: 1},
+			wantErr: `too many arguments: ["foo" "bar"]`,
 		},
 	}
 
@@ -198,8 +198,8 @@ func TestNewEdit_FileParsing(t *testing.T) {
 				Getenv: func(string) string { return "" },
 			}, tt.args)
 
-			if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/edit.go
+++ b/edit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +28,7 @@ type Edit struct {
 
 // Run runs the "restack edit" command.
 func (e *Edit) Run(ctx context.Context) (err error) {
-	tempDir, err := ioutil.TempDir("", "restack.")
+	tempDir, err := os.MkdirTemp("", "restack.")
 	if err != nil {
 		return fmt.Errorf("create temporary directory: %v", err)
 	}

--- a/edit_test.go
+++ b/edit_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/abhinav/restack/internal/editorfake"
-	"github.com/abhinav/restack/internal/iotest"
 	"github.com/abhinav/restack/internal/test"
 	"github.com/abhinav/restack/internal/testwriter"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,7 @@ import (
 var _noop = "noop\n"
 
 func TestEdit(t *testing.T) {
-	dir := iotest.TempDir(t, "edit")
+	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
@@ -108,7 +107,7 @@ func TestEdit_MissingFile(t *testing.T) {
 
 // Handle failures in restacking the instructions.
 func TestEdit_RestackFailed(t *testing.T) {
-	dir := iotest.TempDir(t, "edit-restack-fail")
+	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
@@ -134,7 +133,7 @@ func TestEdit_RestackFailed(t *testing.T) {
 
 // Handle non-zero codes from editors.
 func TestEdit_EditorFailed(t *testing.T) {
-	dir := iotest.TempDir(t, "edit-editor-fail")
+	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
@@ -162,7 +161,7 @@ func TestEdit_EditorFailed(t *testing.T) {
 // Handle failures in renaming if, for example, the file was deleted by the
 // editor.
 func TestEdit_RenameFailed(t *testing.T) {
-	dir := iotest.TempDir(t, "edit-rename-fail")
+	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,

--- a/edit_test.go
+++ b/edit_test.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestEdit(t *testing.T) {
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
-		ioutil.WriteFile(file, []byte(_noop), 0600),
+		os.WriteFile(file, []byte(_noop), 0o600),
 		"write temporary file")
 
 	restackerOutput := "x echo hello world"
@@ -51,7 +52,7 @@ func TestEdit(t *testing.T) {
 	}).Run(ctx)
 	require.NoError(t, err, "edit failed")
 
-	gotOutput, err := ioutil.ReadFile(file)
+	gotOutput, err := os.ReadFile(file)
 	require.NoError(t, err, "read output")
 
 	assert.Equal(t, editorOutput, string(gotOutput),
@@ -75,7 +76,7 @@ func (r *fakeRestacker) Restack(ctx context.Context, req *Request) error {
 	t := r.T
 	r.ran = true
 
-	gotInput, err := ioutil.ReadAll(req.From)
+	gotInput, err := io.ReadAll(req.From)
 	if !assert.NoError(t, err, "read input") {
 		return err
 	}
@@ -111,7 +112,7 @@ func TestEdit_RestackFailed(t *testing.T) {
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
-		ioutil.WriteFile(file, []byte(_noop), 0600),
+		os.WriteFile(file, []byte(_noop), 0o600),
 		"write temporary file")
 
 	ctx := context.Background()
@@ -137,7 +138,7 @@ func TestEdit_EditorFailed(t *testing.T) {
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
-		ioutil.WriteFile(file, []byte{}, 0600),
+		os.WriteFile(file, []byte{}, 0o600),
 		"write temporary file")
 
 	restacker := fakeRestacker{T: t}
@@ -165,7 +166,7 @@ func TestEdit_RenameFailed(t *testing.T) {
 	file := filepath.Join(dir, "git-rebase-todo")
 
 	require.NoError(t,
-		ioutil.WriteFile(file, []byte{}, 0600),
+		os.WriteFile(file, []byte{}, 0o600),
 		"write temporary file")
 
 	restacker := fakeRestacker{T: t}

--- a/edit_test.go
+++ b/edit_test.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/abhinav/restack/internal/editorfake"
+	"github.com/abhinav/restack/internal/iotest"
 	"github.com/abhinav/restack/internal/test"
 	"github.com/abhinav/restack/internal/testwriter"
 	"github.com/stretchr/testify/assert"
@@ -23,9 +23,7 @@ func TestEdit(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
-	require.NoError(t,
-		os.WriteFile(file, []byte(_noop), 0o600),
-		"write temporary file")
+	iotest.WriteFile(t, file, _noop, 0o600)
 
 	restackerOutput := "x echo hello world"
 	restacker := fakeRestacker{
@@ -52,10 +50,7 @@ func TestEdit(t *testing.T) {
 	}).Run(ctx)
 	require.NoError(t, err, "edit failed")
 
-	gotOutput, err := os.ReadFile(file)
-	require.NoError(t, err, "read output")
-
-	assert.Equal(t, editorOutput, string(gotOutput),
+	assert.Equal(t, editorOutput, iotest.ReadFile(t, file),
 		"output mismatch")
 }
 
@@ -111,9 +106,7 @@ func TestEdit_RestackFailed(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
-	require.NoError(t,
-		os.WriteFile(file, []byte(_noop), 0o600),
-		"write temporary file")
+	iotest.WriteFile(t, file, _noop, 0o600)
 
 	ctx := context.Background()
 	err := (&Edit{
@@ -137,9 +130,7 @@ func TestEdit_EditorFailed(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
-	require.NoError(t,
-		os.WriteFile(file, []byte{}, 0o600),
-		"write temporary file")
+	iotest.WriteFile(t, file, "", 0o600)
 
 	restacker := fakeRestacker{T: t}
 	defer restacker.VerifyRan()
@@ -165,9 +156,7 @@ func TestEdit_RenameFailed(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "git-rebase-todo")
 
-	require.NoError(t,
-		os.WriteFile(file, []byte{}, 0o600),
-		"write temporary file")
+	iotest.WriteFile(t, file, "", 0o600)
 
 	restacker := fakeRestacker{T: t}
 	defer restacker.VerifyRan()

--- a/git.go
+++ b/git.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,7 +62,7 @@ func (g *SystemGit) RebaseHeadName(ctx context.Context) (string, error) {
 			return "", err
 		}
 
-		nameBytes, err := ioutil.ReadFile(headFile)
+		nameBytes, err := os.ReadFile(headFile)
 		if err != nil {
 			return "", fmt.Errorf("read %q: %v", headFile, err)
 		}

--- a/git_test.go
+++ b/git_test.go
@@ -2,7 +2,6 @@ package restack
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -132,7 +131,7 @@ func touch(t *testing.T, paths ...string) {
 
 	for _, path := range paths {
 		require.NoError(t,
-			ioutil.WriteFile(path, []byte{}, 0644),
+			os.WriteFile(path, []byte{}, 0o644),
 			"touch %q", path)
 	}
 }

--- a/git_test.go
+++ b/git_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/abhinav/restack/internal/editorfake"
-	"github.com/abhinav/restack/internal/iotest"
 	"github.com/abhinav/restack/internal/ostest"
 	"github.com/abhinav/restack/internal/testwriter"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +16,7 @@ import (
 
 func TestSystemGit_RebaseHeadName(t *testing.T) {
 	ostest.Setenv(t, "HOME", t.TempDir())
-	ostest.Chdir(t, iotest.TempDir(t, "git-rebase-head-name"))
+	ostest.Chdir(t, t.TempDir())
 
 	gitInit(t)
 
@@ -54,7 +53,7 @@ func TestSystemGit_RebaseHeadName(t *testing.T) {
 
 func TestSystemGit_ListBranches(t *testing.T) {
 	ostest.Setenv(t, "HOME", t.TempDir())
-	ostest.Chdir(t, iotest.TempDir(t, "git-list-branches"))
+	ostest.Chdir(t, t.TempDir())
 
 	gitInit(t)
 

--- a/git_test.go
+++ b/git_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/abhinav/restack/internal/editorfake"
+	"github.com/abhinav/restack/internal/iotest"
 	"github.com/abhinav/restack/internal/ostest"
 	"github.com/abhinav/restack/internal/testwriter"
 	"github.com/stretchr/testify/assert"
@@ -130,8 +131,6 @@ func touch(t *testing.T, paths ...string) {
 	t.Helper()
 
 	for _, path := range paths {
-		require.NoError(t,
-			os.WriteFile(path, []byte{}, 0o644),
-			"touch %q", path)
+		iotest.WriteFile(t, path, "", 0o644)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abhinav/restack
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/mock v1.6.0
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/multierr v1.8.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
-	honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2
+	honnef.co/go/tools v0.3.3
 )
 
 require (
@@ -17,9 +17,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	golang.org/x/tools v0.1.10 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/tools v0.1.12 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
-golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -42,8 +42,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -51,11 +51,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
-golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -63,5 +62,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2 h1:utiSabORbG/JeX7MlmKMdmsjwom2+v8zmdb6SoBe4UY=
-honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2/go.mod h1:dZI0HmIvwDMW8owtLBJxTHoeX48yuF5p5pDy3y73jGU=
+honnef.co/go/tools v0.3.3 h1:oDx7VAwstgpYpb3wv0oxiZlxY+foCpRAwY7Vk6XpAgA=
+honnef.co/go/tools v0.3.3/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=

--- a/internal/editorfake/fake.go
+++ b/internal/editorfake/fake.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -24,11 +23,11 @@ import (
 //
 // Use this in TestMain before calling m.Run().
 //
-//  func TestMain(m *testing.M) {
-//    editortest.TryMain()
+//	func TestMain(m *testing.M) {
+//	  editortest.TryMain()
 //
-//    os.Exit(m.Run())
-//  }
+//	  os.Exit(m.Run())
+//	}
 //
 // This is a no-op if not inside a fake editor environment.
 func TryMain() {
@@ -146,7 +145,7 @@ func main(cfgFile string) error {
 	}
 	file := args[0]
 
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("read %q: %v", file, err)
 	}

--- a/internal/editorfake/op.go
+++ b/internal/editorfake/op.go
@@ -2,7 +2,6 @@ package editorfake
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/google/go-cmp/cmp"
@@ -58,7 +57,7 @@ func (*giveContents) optionType() optionType {
 
 func (c *giveContents) run(s *state) error {
 	s.Contents = c.Contents
-	if err := ioutil.WriteFile(s.Path, []byte(s.Contents), 0644); err != nil {
+	if err := os.WriteFile(s.Path, []byte(s.Contents), 0o644); err != nil {
 		return fmt.Errorf("write %q: %v", s.Path, err)
 	}
 	return nil
@@ -79,14 +78,13 @@ func (*addPrefix) optionType() optionType {
 
 func (c *addPrefix) run(s *state) error {
 	s.Contents = c.Prefix + s.Contents
-	if err := ioutil.WriteFile(s.Path, []byte(s.Contents), 0644); err != nil {
+	if err := os.WriteFile(s.Path, []byte(s.Contents), 0o644); err != nil {
 		return fmt.Errorf("write %q: %v", s.Path, err)
 	}
 	return nil
 }
 
-type deleteFile struct {
-}
+type deleteFile struct{}
 
 // DeleteFile informs the editor to delete the file instead of writing to it.
 func DeleteFile() Option {

--- a/internal/editorfake/op_test.go
+++ b/internal/editorfake/op_test.go
@@ -1,7 +1,6 @@
 package editorfake
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func TestGiveContents(t *testing.T) {
 	require.NoError(t,
 		GiveContents("foo").run(&s))
 
-	got, err := ioutil.ReadFile(file)
+	got, err := os.ReadFile(file)
 	require.NoError(t, err, "read %q", file)
 
 	want := "foo"
@@ -46,7 +45,7 @@ func TestAddPrefix(t *testing.T) {
 	s := state{Path: file, Contents: "foo"}
 	require.NoError(t, AddPrefix("bar").run(&s))
 
-	got, err := ioutil.ReadFile(file)
+	got, err := os.ReadFile(file)
 	require.NoError(t, err, "read %q", file)
 
 	want := "barfoo"
@@ -69,7 +68,7 @@ func TestDeleteFile(t *testing.T) {
 		file := filepath.Join(dir, "file")
 
 		require.NoError(t,
-			ioutil.WriteFile(file, []byte("foo"), 0644),
+			os.WriteFile(file, []byte("foo"), 0o644),
 			"write %q", file)
 
 		s := state{Path: file}

--- a/internal/editorfake/op_test.go
+++ b/internal/editorfake/op_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/abhinav/restack/internal/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +26,7 @@ func TestWantContents(t *testing.T) {
 }
 
 func TestGiveContents(t *testing.T) {
-	file := filepath.Join(iotest.TempDir(t, "give-contents"), "file")
+	file := filepath.Join(t.TempDir(), "file")
 
 	s := state{Path: file}
 	require.NoError(t,
@@ -42,7 +41,7 @@ func TestGiveContents(t *testing.T) {
 }
 
 func TestAddPrefix(t *testing.T) {
-	file := filepath.Join(iotest.TempDir(t, "give-contents"), "file")
+	file := filepath.Join(t.TempDir(), "file")
 
 	s := state{Path: file, Contents: "foo"}
 	require.NoError(t, AddPrefix("bar").run(&s))
@@ -56,7 +55,7 @@ func TestAddPrefix(t *testing.T) {
 }
 
 func TestDeleteFile(t *testing.T) {
-	dir := iotest.TempDir(t, "give-contents")
+	dir := t.TempDir()
 
 	t.Run("file does not exist", func(t *testing.T) {
 		file := filepath.Join(dir, "does-not-exist")

--- a/internal/editorfake/op_test.go
+++ b/internal/editorfake/op_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/abhinav/restack/internal/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,11 +32,8 @@ func TestGiveContents(t *testing.T) {
 	require.NoError(t,
 		GiveContents("foo").run(&s))
 
-	got, err := os.ReadFile(file)
-	require.NoError(t, err, "read %q", file)
-
 	want := "foo"
-	assert.Equal(t, want, string(got), "file contents mismatch")
+	assert.Equal(t, want, iotest.ReadFile(t, file), "file contents mismatch")
 	assert.Equal(t, want, s.Contents, "state.Contents mismatch")
 }
 
@@ -45,11 +43,8 @@ func TestAddPrefix(t *testing.T) {
 	s := state{Path: file, Contents: "foo"}
 	require.NoError(t, AddPrefix("bar").run(&s))
 
-	got, err := os.ReadFile(file)
-	require.NoError(t, err, "read %q", file)
-
 	want := "barfoo"
-	assert.Equal(t, want, string(got), "file contents mismatch")
+	assert.Equal(t, want, iotest.ReadFile(t, file), "file contents mismatch")
 	assert.Equal(t, want, s.Contents, "state.Contents mismatch")
 }
 
@@ -67,9 +62,7 @@ func TestDeleteFile(t *testing.T) {
 	t.Run("file exists", func(t *testing.T) {
 		file := filepath.Join(dir, "file")
 
-		require.NoError(t,
-			os.WriteFile(file, []byte("foo"), 0o644),
-			"write %q", file)
+		iotest.WriteFile(t, file, "foo", 0o644)
 
 		s := state{Path: file}
 		require.NoError(t, DeleteFile().run(&s))

--- a/internal/iotest/file.go
+++ b/internal/iotest/file.go
@@ -1,6 +1,7 @@
 package iotest
 
 import (
+	"io/fs"
 	"os"
 
 	"github.com/abhinav/restack/internal/test"
@@ -29,4 +30,31 @@ func TempFile(t test.T, prefix string) *os.File {
 	})
 
 	return f
+}
+
+// WriteFile is a shortcut to os.WriteFile for tests.
+func WriteFile(t test.T, path, body string, perm os.FileMode) {
+	t.Helper()
+
+	require.NoError(t,
+		os.WriteFile(path, []byte(body), perm),
+		"write %q", path)
+}
+
+// ReadFile is a shortcut to os.ReadFile for tests.
+func ReadFile(t test.T, path string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(path)
+	require.NoError(t, err, "read %q", path)
+	return string(body)
+}
+
+// Stat is a shortcut to os.Stat for tests.
+func Stat(t test.T, path string) fs.FileInfo {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info
 }

--- a/internal/iotest/file_test.go
+++ b/internal/iotest/file_test.go
@@ -1,7 +1,9 @@
 package iotest
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,8 +33,7 @@ func TestTempFile(t *testing.T) {
 		file := TempFile(&ft, "foo")
 		require.NotNil(t, file, "expected a file")
 
-		info, err := os.Stat(file.Name())
-		require.NoError(t, err)
+		info := Stat(t, file.Name())
 
 		mode := info.Mode()
 		assert.True(t, mode.IsRegular(),
@@ -40,7 +41,7 @@ func TestTempFile(t *testing.T) {
 
 		ft.runCleanup()
 
-		info, err = os.Stat(file.Name())
+		info, err := os.Stat(file.Name())
 		assert.ErrorIs(t, err, os.ErrNotExist,
 			"file should not exist after cleanup, got %v", info)
 	})
@@ -48,5 +49,21 @@ func TestTempFile(t *testing.T) {
 	t.Run("already closed", func(t *testing.T) {
 		f := TempFile(t, "foo")
 		require.NoError(t, f.Close(), "close %q", f.Name())
+	})
+}
+
+func TestReadWriteStatFile(t *testing.T) {
+	t.Parallel()
+
+	dst := filepath.Join(t.TempDir(), "foo")
+	WriteFile(t, dst, "hello", 0o644)
+	assert.Equal(t, "hello", ReadFile(t, dst))
+	assert.Equal(t, fs.FileMode(0o644), Stat(t, dst).Mode())
+
+	t.Run("already exists", func(t *testing.T) {
+		WriteFile(t, dst, "world", 0o755)
+		assert.Equal(t, "world", ReadFile(t, dst))
+		assert.Equal(t, fs.FileMode(0o644), Stat(t, dst).Mode(),
+			"WriteFile should not change permissions for existing files")
 	})
 }

--- a/internal/iotest/temp.go
+++ b/internal/iotest/temp.go
@@ -9,24 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TempDir creates a new temporary directory inside the current test context.
-//
-// It deletes the directory when the test finishes.
-func TempDir(t test.T, prefix string) string {
-	t.Helper()
-
-	dir, err := ioutil.TempDir("", prefix)
-	require.NoError(t, err, "make tempdir")
-
-	t.Cleanup(func() {
-		assert.NoError(t,
-			os.RemoveAll(dir),
-			"delete tempdir %q", dir)
-	})
-
-	return dir
-}
-
 // TempFile creates a new temporary file inside the current test context.
 //
 // It deletes the file when the test finishes.

--- a/internal/iotest/temp.go
+++ b/internal/iotest/temp.go
@@ -1,7 +1,6 @@
 package iotest
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/abhinav/restack/internal/test"
@@ -15,7 +14,7 @@ import (
 func TempFile(t test.T, prefix string) *os.File {
 	t.Helper()
 
-	f, err := ioutil.TempFile("", prefix)
+	f, err := os.CreateTemp("", prefix)
 	require.NoError(t, err, "make tempfile")
 	name := f.Name()
 

--- a/internal/iotest/temp_test.go
+++ b/internal/iotest/temp_test.go
@@ -24,25 +24,6 @@ func (t *fakeT) runCleanup() {
 	}
 }
 
-func TestTempDir(t *testing.T) {
-	ft := fakeT{T: t}
-
-	dir := TempDir(&ft, "foo")
-	assert.NotEmpty(t, dir, "expected a directory")
-
-	info, err := os.Stat(dir)
-	require.NoError(t, err)
-
-	assert.True(t, info.IsDir(),
-		"expected directory, got %v", info.Mode())
-
-	ft.runCleanup()
-
-	info, err = os.Stat(dir)
-	assert.ErrorIs(t, err, os.ErrNotExist,
-		"directory should not exist after cleanup, got %v", info)
-}
-
 func TestTempFile(t *testing.T) {
 	t.Run("automatically close", func(t *testing.T) {
 		ft := fakeT{T: t}

--- a/internal/ostest/dir_test.go
+++ b/internal/ostest/dir_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/abhinav/restack/internal/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +13,7 @@ func TestChdir(t *testing.T) {
 	old, err := os.Getwd()
 	require.NoError(t, err, "get cwd")
 
-	tempdir := iotest.TempDir(t, "chdir")
+	tempdir := t.TempDir()
 
 	// On macOS, tempdir may be a symlink that reports a different working
 	// directory once Chdir-ed into.

--- a/internal/test/t.go
+++ b/internal/test/t.go
@@ -7,4 +7,5 @@ type T interface {
 	FailNow()
 	Helper()
 	Logf(string, ...interface{})
+	TempDir() string
 }

--- a/io_test.go
+++ b/io_test.go
@@ -3,7 +3,6 @@ package restack
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -13,20 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Shortcut to ioutil.WriteFile.
+// Shortcut to os.WriteFile.
 func writeFile(t testing.TB, path, body string, perm os.FileMode) {
 	t.Helper()
 
 	require.NoError(t,
-		ioutil.WriteFile(path, []byte(body), perm),
+		os.WriteFile(path, []byte(body), perm),
 		"write %q", path)
 }
 
-// Shortcut to ioutil.ReadFile + os.Stat.
+// Shortcut to os.ReadFile + os.Stat.
 func readFileAndMode(t testing.TB, path string) (string, os.FileMode) {
 	t.Helper()
 
-	body, err := ioutil.ReadFile(path)
+	body, err := os.ReadFile(path)
 	require.NoError(t, err, "read %q", path)
 
 	info, err := os.Stat(path)
@@ -45,19 +44,18 @@ func hijackRename(t testing.TB, newFn func(string, string) error) {
 }
 
 func TestRenameFile(t *testing.T) {
-
 	t.Run("success", func(t *testing.T) {
 		tempDir := t.TempDir()
 		src := filepath.Join(tempDir, "foo")
 		dst := filepath.Join(tempDir, "bar")
 
-		writeFile(t, src, "body", 0644)
+		writeFile(t, src, "body", 0o644)
 		require.NoError(t, renameFile(src, dst),
 			"rename failed")
 
 		got, perm := readFileAndMode(t, dst)
 		assert.Equal(t, "body", got, "body mismatch")
-		assert.Equal(t, os.FileMode(0644), perm,
+		assert.Equal(t, os.FileMode(0o644), perm,
 			"permissions mismatch")
 
 		_, err := os.Stat(src)
@@ -73,13 +71,13 @@ func TestRenameFile(t *testing.T) {
 		src := filepath.Join(tempDir, "foo")
 		dst := filepath.Join(tempDir, "bar")
 
-		writeFile(t, src, "body", 0644)
+		writeFile(t, src, "body", 0o644)
 		require.NoError(t, renameFile(src, dst),
 			"rename failed")
 
 		got, perm := readFileAndMode(t, dst)
 		assert.Equal(t, "body", got, "body mismatch")
-		assert.Equal(t, os.FileMode(0644), perm,
+		assert.Equal(t, os.FileMode(0o644), perm,
 			"permissions mismatch")
 
 		_, err := os.Stat(src)
@@ -95,7 +93,7 @@ func TestRenameFile(t *testing.T) {
 		src := filepath.Join(tempDir, "foo")
 		dst := filepath.Join(tempDir, "bar")
 
-		writeFile(t, src, "body", 0644)
+		writeFile(t, src, "body", 0o644)
 		require.Error(t, renameFile(src, dst),
 			"rename should fail")
 	})
@@ -111,14 +109,14 @@ func TestUnsafeRenameFile(t *testing.T) {
 		src := filepath.Join(tempDir, "foo")
 		dst := filepath.Join(tempDir, "bar")
 
-		writeFile(t, src, "body", 0644)
+		writeFile(t, src, "body", 0o644)
 
 		require.NoError(t, unsafeRenameFile(src, dst),
 			"unsafe rename failed")
 
 		got, perm := readFileAndMode(t, dst)
 		assert.Equal(t, "body", got, "body mismatch")
-		assert.Equal(t, os.FileMode(0644), perm,
+		assert.Equal(t, os.FileMode(0o644), perm,
 			"permissions mismatch")
 
 		_, err := os.Stat(src)
@@ -132,15 +130,15 @@ func TestUnsafeRenameFile(t *testing.T) {
 		src := filepath.Join(tempDir, "foo")
 		dst := filepath.Join(tempDir, "bar")
 
-		writeFile(t, src, "body1", 0755)
-		writeFile(t, dst, "body2", 0600)
+		writeFile(t, src, "body1", 0o755)
+		writeFile(t, dst, "body2", 0o600)
 
 		require.NoError(t, unsafeRenameFile(src, dst),
 			"unsafe rename failed")
 
 		got, perm := readFileAndMode(t, dst)
 		assert.Equal(t, "body1", got, "body mismatch")
-		assert.Equal(t, os.FileMode(0755), perm,
+		assert.Equal(t, os.FileMode(0o755), perm,
 			"permissions mismatch")
 
 		_, err := os.Stat(src)
@@ -155,7 +153,7 @@ func TestUnsafeRenameFile(t *testing.T) {
 		dst := filepath.Join(tempDir, "bar", "baz", "qux")
 		// Parent directories don't exist.
 
-		writeFile(t, src, "body", 0644)
+		writeFile(t, src, "body", 0o644)
 
 		err := unsafeRenameFile(src, dst)
 		require.Error(t, err, "unsafe rename should fail")
@@ -163,7 +161,7 @@ func TestUnsafeRenameFile(t *testing.T) {
 		// src should rename unchanged.
 		got, perm := readFileAndMode(t, src)
 		assert.Equal(t, "body", got)
-		assert.Equal(t, os.FileMode(0644), perm,
+		assert.Equal(t, os.FileMode(0o644), perm,
 			"permissions mismatch")
 	})
 

--- a/scripts/extract_changelog.go
+++ b/scripts/extract_changelog.go
@@ -16,6 +16,9 @@ func main() {
 	}
 
 	version := os.Args[1]
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
 	if err := run(version, os.Stdout); err != nil {
 		log.Fatal(err)
 	}
@@ -30,7 +33,7 @@ const (
 )
 
 func run(version string, out io.Writer) error {
-	file, err := os.OpenFile("CHANGELOG.md", os.O_RDONLY, 0444)
+	file, err := os.OpenFile("CHANGELOG.md", os.O_RDONLY, 0o444)
 	if err != nil {
 		return err
 	}

--- a/setup.go
+++ b/setup.go
@@ -5,7 +5,6 @@ import (
 	_ "embed" // for setup script
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,12 +35,12 @@ func (s *Setup) Run(ctx context.Context) error {
 
 	// TODO: Use config dir in the future
 	restackDir := filepath.Join(home, ".restack")
-	if err := os.MkdirAll(restackDir, 0755); err != nil {
+	if err := os.MkdirAll(restackDir, 0o755); err != nil {
 		return fmt.Errorf("create directory %q: %v", restackDir, err)
 	}
 
 	editCmd := filepath.Join(restackDir, "edit.sh")
-	if err := ioutil.WriteFile(editCmd, _editScript, 0755); err != nil {
+	if err := os.WriteFile(editCmd, _editScript, 0o755); err != nil {
 		return fmt.Errorf("write file %q: %v", editCmd, err)
 	}
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/abhinav/restack/internal/iotest"
 	"github.com/abhinav/restack/internal/ostest"
 	"github.com/abhinav/restack/internal/testwriter"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestSetup(t *testing.T) {
-	home := iotest.TempDir(t, "setup")
+	home := t.TempDir()
 	ostest.Setenv(t, "HOME", home)
 
 	twriter := testwriter.New(t)

--- a/setup_test.go
+++ b/setup_test.go
@@ -3,11 +3,11 @@ package restack
 import (
 	"bytes"
 	"context"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/abhinav/restack/internal/iotest"
 	"github.com/abhinav/restack/internal/ostest"
 	"github.com/abhinav/restack/internal/testwriter"
 	"github.com/stretchr/testify/assert"
@@ -28,8 +28,7 @@ func TestSetup(t *testing.T) {
 	require.NoError(t, setup.Run(ctx), "setup must not fail")
 
 	scriptPath := filepath.Join(home, ".restack/edit.sh")
-	scriptInfo, err := os.Stat(scriptPath)
-	require.NoError(t, err, "want edit script: %v", scriptPath)
+	scriptInfo := iotest.Stat(t, scriptPath)
 
 	mode := scriptInfo.Mode()
 	assert.NotZero(t, mode&0100, "edit.sh: want executable, got %v", mode)


### PR DESCRIPTION
This includes several changes that attempt to modernize some of the code to
more accurately reflect current practices:

- Use Go 1.19
- Don't use ioutil
- Use t.TempDir instead of custom wrappers
- Don't use top-level error vars or types until needed
