### PR TITLE
release: Enable build-std, panic_immediate_abort, etc.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
       with:
         target: ${{ matrix.target }}
         profile: minimal
+        components: rust-src
 
     - name: Install additional toolchains
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.extra_toolchain != '' }}
@@ -70,7 +71,11 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --target ${{ matrix.target }} --release
+        args: >-
+          --target ${{ matrix.target }}
+          --release
+          -Z build-std=std,panic_abort
+          -Z build-std-features=panic_immediate_abort
 
     - name: Strip binary
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0 (unreleased)
 
-- Reduce binary size by over 70%.
+- Reduce binary size significantly.
 
 ## v0.5.4 (2022-08-30)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ rstest = "0.15.0"
 
 [profile.release]
 lto = true
+panic = "abort"
+opt-level = "z"
 
 [workspace]
 members = [".", "./testtools"]


### PR DESCRIPTION
Significantly reduces the size of the released binary.
