### PR TITLE
Respect core.commentChar during restacking

### DIFF
--- a/.changes/unreleased/Added-20230705-054852.yaml
+++ b/.changes/unreleased/Added-20230705-054852.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support core.commentChar during restacking.
+time: 2023-07-05T05:48:52.57829209-07:00

--- a/fixtures/empty_commit_comment_char_auto.sh
+++ b/fixtures/empty_commit_comment_char_auto.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+git config core.commentChar 'auto'
+git commit --allow-empty -m "empty commit"

--- a/fixtures/empty_commit_comment_char_auto.tar.xz
+++ b/fixtures/empty_commit_comment_char_auto.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4242292b3e1196f39dcd0a48a075308d1d282bfb6e2d64b27aee06f7a472aca
+size 10396

--- a/fixtures/simple_stack_comment_char.sh
+++ b/fixtures/simple_stack_comment_char.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This fixture contains a simple stack of commits.
+#
+# o [main] initial commit
+# |
+# o [foo] foo
+# |
+# o [bar] bar
+# |
+# o [baz, wip] baz
+#
+# It also uses ';' as the comment character.
+
+die() {
+	echo >&2 "$@"
+	exit 1
+}
+
+add_and_commit() {
+	[[ $# -eq 1 ]] || die "add_and_commit expects one argument"
+
+	echo "$1" > "$1"
+	git add "$1"
+	git commit -m "add $1"
+}
+
+git commit --allow-empty -m "empty commit"
+git config core.commentChar ';'
+
+git checkout -b foo
+add_and_commit foo
+
+git checkout -b bar
+add_and_commit bar
+
+git checkout -b baz
+add_and_commit baz
+
+git checkout -b wip

--- a/fixtures/simple_stack_comment_char.tar.xz
+++ b/fixtures/simple_stack_comment_char.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9744955fe3c7c62ae19dab0943d8f27576e58164130450dcd09c715bf0c7c9c
+size 11892

--- a/src/git.rs
+++ b/src/git.rs
@@ -39,6 +39,9 @@ pub trait Git {
         let git_dir = self.git_dir(dir).context("Failed to find .git directory")?;
         rebase_head_name(&git_dir)
     }
+
+    /// Reports the character used for comments in the repository at the given path.
+    fn comment_char(&self, dir: &path::Path) -> Result<char>;
 }
 
 const REBASE_STATE_DIRS: &[&str] = &["rebase-apply", "rebase-merge"];

--- a/tests/edit/mod.rs
+++ b/tests/edit/mod.rs
@@ -26,10 +26,11 @@ where
 }
 
 #[rstest]
-#[case::editor_flag(true)]
-#[case::editor_env(false)]
-fn simple_stack(#[case] editor_flag: bool) -> Result<()> {
-    let repo_fixture = open_fixture("simple_stack.sh")?;
+#[case::editor_flag(true, "simple_stack.sh")]
+#[case::editor_env(false, "simple_stack.sh")]
+#[case::comment_char(false, "simple_stack_comment_char.sh")]
+fn simple_stack(#[case] editor_flag: bool, #[case] fixture: &str) -> Result<()> {
+    let repo_fixture = open_fixture(fixture)?;
 
     let editor = FIXTURES_DIR.join("bin/add_break.sh");
 


### PR DESCRIPTION
Git supports setting `core.commentChar` to change
which character it uses for comments in commit messages.
This affects the rebase instruction list that restack sees.

This change adds support to restack for this configuration.
If set, the specified character will be used during restacking;
both while searching for comments and when adding comments.

Resolves #72
