### PR TITLE
test: Ignore global Git config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: ## build the binary
 
 .PHONY: test
 test: ## run all tests
-	cargo nextest run --locked --workspace --no-fail-fast $(TEST_ARGS)
+	GIT_CONFIG_GLOBAL= cargo nextest run --locked --workspace --no-fail-fast $(TEST_ARGS)
 
 _COV_FLAGS = --hide-instantiations
 


### PR DESCRIPTION
Don't let global git configuration affect the test runs.
Right now, if you set, say `core.commentString`, tests will fail.