### PR TITLE
Support core.commentString configuration

### DIFF
--- a/.changes/unreleased/Added-20240802-051535.yaml
+++ b/.changes/unreleased/Added-20240802-051535.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support core.commentString during restacking.
+time: 2024-08-02T05:15:35.963985-07:00

--- a/fixtures/simple_stack_comment_string.sh
+++ b/fixtures/simple_stack_comment_string.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This fixture contains a simple stack of commits.
+#
+# o [main] initial commit
+# |
+# o [foo] foo
+# |
+# o [bar] bar
+# |
+# o [baz, wip] baz
+#
+# It also uses '#:' as the comment string.
+
+die() {
+	echo >&2 "$@"
+	exit 1
+}
+
+add_and_commit() {
+	[[ $# -eq 1 ]] || die "add_and_commit expects one argument"
+
+	echo "$1" > "$1"
+	git add "$1"
+	git commit -m "add $1"
+}
+
+git commit --allow-empty -m "empty commit"
+git config core.commentString "#:"
+
+git checkout -b foo
+add_and_commit foo
+
+git checkout -b bar
+add_and_commit bar
+
+git checkout -b baz
+add_and_commit baz
+
+git checkout -b wip

--- a/fixtures/simple_stack_comment_string.tar.xz
+++ b/fixtures/simple_stack_comment_string.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2ac91e798675c0f391c91b3d770e67324daa25b7c91102e49715abfdd40bad8
+size 11908

--- a/src/git.rs
+++ b/src/git.rs
@@ -40,8 +40,8 @@ pub trait Git {
         rebase_head_name(&git_dir)
     }
 
-    /// Reports the character used for comments in the repository at the given path.
-    fn comment_char(&self, dir: &path::Path) -> Result<char>;
+    /// Reports the string prefix used for comments in the repository at the given path.
+    fn comment_string(&self, dir: &path::Path) -> Result<String>;
 }
 
 const REBASE_STATE_DIRS: &[&str] = &["rebase-apply", "rebase-merge"];

--- a/src/restack/tests.rs
+++ b/src/restack/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use std::path;
 
 use anyhow::Result;
@@ -13,6 +11,7 @@ struct StubGit {
     branches: Vec<git::Branch>,
     rebase_head_name: String,
     comment_char: Option<char>,
+    comment_string: Option<String>,
 }
 
 impl git::Git for StubGit {
@@ -36,8 +35,12 @@ impl git::Git for StubGit {
         Ok(self.rebase_head_name.clone())
     }
 
-    fn comment_char(&self, _: &path::Path) -> Result<char> {
-        Ok(self.comment_char.unwrap_or('#'))
+    fn comment_string(&self, _: &path::Path) -> Result<String> {
+        if let Some(s) = &self.comment_string {
+            return Ok(s.to_string());
+        }
+
+        Ok(self.comment_char.unwrap_or('#').to_string())
     }
 }
 
@@ -69,6 +72,7 @@ fn restack_test(test: &TestCase) -> Result<()> {
         branches,
         rebase_head_name: test.rebase_head_name.to_owned(),
         comment_char: test.comment_char,
+        comment_string: None,
     };
 
     let cfg = Config::new(tempdir.path(), stub_git);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -80,6 +80,7 @@ pub fn run(mut parser: lexopt::Parser) -> Result<()> {
         path.push("edit.sh");
         fs::OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .mode(0o755)
             .open(&path)

--- a/tests/edit/mod.rs
+++ b/tests/edit/mod.rs
@@ -29,6 +29,7 @@ where
 #[case::editor_flag(true, "simple_stack.sh")]
 #[case::editor_env(false, "simple_stack.sh")]
 #[case::comment_char(false, "simple_stack_comment_char.sh")]
+#[case::comment_char(false, "simple_stack_comment_string.sh")]
 fn simple_stack(#[case] editor_flag: bool, #[case] fixture: &str) -> Result<()> {
     let repo_fixture = open_fixture(fixture)?;
 


### PR DESCRIPTION
The core.commentChar configuration was superseded by core.commentString
which allows for a multi-character string instead of a single character.

This commit adds support for core.commentString handling.
The existing comment_char method was renamed to comment_string
which internally falls back to core.commentChar
if core.commentString is unset.