### PR TITLE
ci/release: Fix broken cross-compilation setup

### DIFF
--- a/.changes/unreleased/Changed-20240802-071633.yaml
+++ b/.changes/unreleased/Changed-20240802-071633.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'linux-arm64: Binary is no longer statically linked.'
+time: 2024-08-02T07:16:33.678855-07:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,19 +24,17 @@ jobs:
           - slug: linux-amd64
             target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            extra_pkgs: musl-tools
+            strip: x86_64-linux-musl-strip
 
           - slug: linux-arm64
-            target: aarch64-unknown-linux-musl
+            target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            musl-cross: aarch64-linux-musl-cross
-            strip: aarch64-linux-musl-strip
+            strip: aarch64-linux-gnu-strip
             no-build-std: true
 
           - slug: linux-armv7
             target: armv7-unknown-linux-musleabihf
             os: ubuntu-latest
-            musl-cross: armv7l-linux-musleabihf-cross
             strip: armv7l-linux-musleabihf-strip
             no-build-std: true
 
@@ -76,14 +74,8 @@ jobs:
           --no-self-update
     - uses: Swatinem/rust-cache@v2
 
-    - name: Install extra packages
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.extra_pkgs != '' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.extra_pkgs }}
-
     - name: Install Cross
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.musl-cross != '' }}
+      if: matrix.os == 'ubuntu-latest' && matrix.target != ''
       run: |
         dir="$RUNNER_TEMP/cross-download"
         mkdir "$dir"
@@ -139,7 +131,7 @@ jobs:
     - name: Upload archive
       uses: actions/upload-artifact@v4
       with:
-        name: restack-archive
+        name: restack-${{ matrix.slug }}
         path: restack-*.tar.gz
 
   release:
@@ -176,7 +168,9 @@ jobs:
     - name: Download archives
       uses: actions/download-artifact@v4
       with:
-        name: restack-archive
+        path: .
+        pattern: restack-*
+        merge-multiple: true
 
     - name: Determine version number (push)
       if:  github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           - slug: linux-armv7
             target: armv7-unknown-linux-musleabihf
             os: ubuntu-latest
-            strip: armv7l-linux-musleabihf-strip
+            strip: arm-linux-musleabihf-strip
             no-build-std: true
 
           # macOS
@@ -120,7 +120,7 @@ jobs:
           "$PWD/target:/target:Z" \
           "ghcr.io/cross-rs/${{ matrix.target }}:main" \
           "${{ matrix.strip }}" \
-          "/$BIN"
+          "/target/${{ matrix.target }}/release/restack"
 
     - name: Prepare archive
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
           - slug: linux-arm64
             target: aarch64-unknown-linux-musl
             os: ubuntu-latest
-            linker: aarch64-linux-musl-gcc
             musl-cross: aarch64-linux-musl-cross
             strip: aarch64-linux-musl-strip
             no-build-std: true
@@ -37,7 +36,6 @@ jobs:
           - slug: linux-armv7
             target: armv7-unknown-linux-musleabihf
             os: ubuntu-latest
-            linker: armv7l-linux-musleabihf-gcc
             musl-cross: armv7l-linux-musleabihf-cross
             strip: armv7l-linux-musleabihf-strip
             no-build-std: true
@@ -49,6 +47,10 @@ jobs:
           - slug: darwin-arm64
             target: aarch64-apple-darwin
             os: macos-latest
+
+    env:
+      CARGO: cargo
+      CROSS_VERSION: v0.2.5
 
     steps:
 
@@ -80,27 +82,21 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ${{ matrix.extra_pkgs }}
 
-    - name: Install musl cross-compilation toolchain
+    - name: Install Cross
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.musl-cross != '' }}
       run: |
-        mkdir -p "$HOME/.local"
-        curl -o /tmp/musl.tgz https://musl.cc/${{ matrix.musl-cross }}.tgz
-        tar -xzf /tmp/musl.tgz -C "$HOME/.local"
-        echo "$HOME/.local/${{ matrix.musl-cross }}/bin" >> "$GITHUB_PATH"
-
-    - name: Configure linker
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.linker != '' }}
-      run: |
-        mkdir -p .cargo
-        cat > .cargo/config.toml <<EOF
-        [target.${{ matrix.target }}]
-        linker = "${{ matrix.linker }}"
-        EOF
+        dir="$RUNNER_TEMP/cross-download"
+        mkdir "$dir"
+        echo "$dir" >> "$GITHUB_PATH"
+        cd "$dir"
+        curl -LO "https://github.com/cross-rs/cross/releases/download/$CROSS_VERSION/cross-x86_64-unknown-linux-musl.tar.gz"
+        tar xf cross-x86_64-unknown-linux-musl.tar.gz
+        echo "CARGO=cross" >> "$GITHUB_ENV"
 
     - name: Build (build-std)
       if: ${{ !matrix.no-build-std }}
       run: |
-        cargo build \
+        ${{ env.CARGO }} build \
           --target ${{ matrix.target }} \
           --locked \
           --release \
@@ -110,18 +106,29 @@ jobs:
     - name: Build (no-build-std)
       if: ${{ matrix.no-build-std }}
       run: |
-        cargo build \
+        ${{ env.CARGO }} build \
           --target ${{ matrix.target }} \
           --locked \
           --release
 
-    - name: Strip binary
+    - name: Strip release binary (macos)
+      if: matrix.os == 'macos-latest'
       run: |
         strip=${{ matrix.strip || 'strip' }}
         exe=target/${{ matrix.target }}/release/restack
         echo "Before: $(wc -c < "$exe") bytes"
         "$strip" target/${{ matrix.target }}/release/restack
         echo "After: $(wc -c < "$exe") bytes"
+
+    - name: Strip release binary (cross)
+      if: env.CARGO == 'cross'
+      shell: bash
+      run: |
+        docker run --rm -v \
+          "$PWD/target:/target:Z" \
+          "ghcr.io/cross-rs/${{ matrix.target }}:main" \
+          "${{ matrix.strip }}" \
+          "/$BIN"
 
     - name: Prepare archive
       run: |


### PR DESCRIPTION
Changes in the ecosystem since last release
have broken the cross-compilation setup.
Fix it again, use the 'cross' tool to cross-compile.

Unfortunately, it seems that the musl build for Linux ARM64 doesn't work anymore
so switching back to gnu for that target.
