### PR TITLE
chore: Drop io_error_more feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@
 
 #![warn(missing_docs)]
 #![feature(exit_status_error)]
-#![feature(io_error_more)]
 
 use anyhow::{anyhow, bail, Result};
 


### PR DESCRIPTION
The io_error_more feature hasn't been stabilized yet.
It's easy enough to do this without it.