### PR TITLE
$GOPATH usage in edit.sh looks obsolete

### DIFF
--- a/src/edit.sh
+++ b/src/edit.sh
@@ -3,13 +3,6 @@
 editor=$(git var GIT_EDITOR)
 restack=$(command -v restack || echo "")
 
-# $GOPATH/bin is not on $PATH but restack is installed.
-if [ -z "$restack" ]; then
-	if [ -n "$GOPATH" ] && [ -x "$GOPATH/bin/restack" ]; then
-		restack="$GOPATH/bin/restack"
-	fi
-fi
-
 if [ -n "$restack" ]; then
 	"$restack" edit --editor="$editor" "$@"
 else


### PR DESCRIPTION
is this a leftover from before the switch to rust? if not, please ignore this pr.